### PR TITLE
Updated load_default_labware() function

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 BIIE-DeepIR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PYPI.md
+++ b/PYPI.md
@@ -54,16 +54,12 @@ Perform the operations in the `ot_handler` root folder.
 
 ## 4. Upload to PyPI
 
-- (Optional) First, upload to Test PyPI to ensure everything works:
-
-  ```bash
-  twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-  ```
-
 - Then, upload the final version to the main PyPI repository:
 
   ```bash
   twine upload dist/*
   ```
+  
+  When prompted, paste your API token with the pypi- pefix.
 
 - You will be prompted to enter your PyPI credentials.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Before getting started with the liquid handler programming, it's worth reading t
 
 Visit the [issue tracker](https://app.asana.com/0/1209175521795471/1209175611695523) to see the current list of issues and planned features.
 
+## Version 0.1.1
+
+New changes in this version:
+
+- `opentrons.log` -> `ot_handler.log` and is now located in the working directory
+- `default_layout.ot2` is now located in the working directory
+
 ## Setup
 
 ### Prerequisites

--- a/ot_handler/__init__.py
+++ b/ot_handler/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from .liquid_handler import LiquidHandler

--- a/ot_handler/liquid_handler.py
+++ b/ot_handler/liquid_handler.py
@@ -408,9 +408,6 @@ class LiquidHandler:
             with open(default_file) as f:
                 default_layout = json.load(f)
 
-            for deck_position, model_string in default_layout["labware"].items():
-                self.load_labware(model_string, deck_position)
-
             for deck_position, model_string in default_layout["multichannel_tips"].items():
                 self.load_tips(model_string, deck_position, single_channel=False)
 
@@ -419,6 +416,9 @@ class LiquidHandler:
 
             for location, model_name in default_layout["modules"].items():
                 self.load_module(model_name, location)
+
+            for deck_position, model_string in default_layout["labware"].items():
+                self.load_labware(model_string, deck_position)                
 
         except FileNotFoundError:
             logging.error("No default layout file found. No default labware loaded")        

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as req:
 
 setuptools.setup(
     name="ot_handler",  
-    version="0.1.0",    
+    version="0.1.1",    
     author="Oskari Vinko",
     author_email="oskari.vinko@immune.engineering",
     description="A comprehensive solution for automating liquid handling tasks on the Opentrons OT-2.",


### PR DESCRIPTION
Labware is now loaded after modules in 'load_default_labware()' method. This enables loading of adapters on the modules as part of a default deck setup. 